### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,10 +31,10 @@ jobs:
         uses: actions/checkout@v3
       - id: git-x
         run: |
-          echo "::set-output name=git-version::$(git describe --tags --always)"
+          echo "git-version=$(git describe --tags --always)" >> $GITHUB_OUTPUT
       - id: git-branch
         run: |
-          echo "::set-output name=git-branch::$(echo ${GITHUB_REF##*/} | tr '[A-Z]' '[a-z]')"
+          echo "git-branch=$(echo ${GITHUB_REF##*/} | tr '[A-Z]' '[a-z]')" >> $GITHUB_OUTPUT
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,10 +31,10 @@ jobs:
         uses: actions/checkout@v3
       - id: git-x
         run: |
-          echo "git-version=$(git describe --tags --always)" >> $GITHUB_OUTPUT
+          echo "git-version=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
       - id: git-branch
         run: |
-          echo "git-branch=$(echo ${GITHUB_REF##*/} | tr '[A-Z]' '[a-z]')" >> $GITHUB_OUTPUT
+          echo "git-branch=$(echo ${GITHUB_REF##*/} | tr '[A-Z]' '[a-z]')" >> "$GITHUB_OUTPUT"
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2 


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


